### PR TITLE
Update VoiceChannel when client is moved. (#23)

### DIFF
--- a/SharpLink/Enums/SessionChange.cs
+++ b/SharpLink/Enums/SessionChange.cs
@@ -5,5 +5,6 @@
         Connect,
         Disconnect,
         MoveNode,
+        Moved
     }
 }

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -85,7 +85,7 @@ namespace SharpLink
                     }
                     else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel == null)
                     {
-                        logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Disconnected)", LogSeverity.Debug);
+                        logger.Log($"VOICE_STATE_UPDATE({oldVoiceState.VoiceChannel.Guild.Id}, Disconnected)", LogSeverity.Debug);
 
                         // Disconnected
                         LavalinkPlayer player = players[oldVoiceState.VoiceChannel.Guild.Id];
@@ -95,6 +95,18 @@ namespace SharpLink
                             player.SetSessionId("");
                             await player.UpdateSessionAsync(SessionChange.Disconnect, oldVoiceState.VoiceChannel.Guild.Id);
                             players.Remove(oldVoiceState.VoiceChannel.Guild.Id);
+                        }
+                    }
+                    else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel != null && oldVoiceState.VoiceChannel.Id != newVoiceState.VoiceChannel.Id)
+                    {
+                        logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Moved)", LogSeverity.Debug);
+
+                        // Moved
+                        LavalinkPlayer player = players[oldVoiceState.VoiceChannel.Guild.Id];
+
+                        if (player != null)
+                        {
+                            await player.UpdateSessionAsync(SessionChange.Moved, newVoiceState.VoiceChannel);
                         }
                     }
                 }

--- a/SharpLink/LavalinkPlayer.cs
+++ b/SharpLink/LavalinkPlayer.cs
@@ -16,7 +16,7 @@ namespace SharpLink
         public bool Playing { get; private set; }
         public long CurrentPosition { get; private set; }
         public LavalinkTrack CurrentTrack { get; private set; }
-        public IVoiceChannel VoiceChannel { get; }
+        public IVoiceChannel VoiceChannel { get; private set; }
         #endregion
 
         internal LavalinkPlayer(LavalinkManager manager, IVoiceChannel voiceChannel)
@@ -222,6 +222,13 @@ namespace SharpLink
                         data.Add("guildId", guildId.ToString());
 
                         await manager.GetWebSocket().SendAsync(data.ToString());
+
+                        break;
+                    }
+
+                case SessionChange.Moved:
+                    {
+                        VoiceChannel = (IVoiceChannel)changeData;
 
                         break;
                     }


### PR DESCRIPTION
* Update VoiceChannel when client is moved.

* Check if player exists before updating VoiceChannel

* Fix Typo

New VoiceChannel is null, so we can't get Guild Id from that.

* SessionChange Consistency